### PR TITLE
Fix eshail.batc.org.uk websocket protocol.

### DIFF
--- a/QO-100 WB Live Tune/Form1.cs
+++ b/QO-100 WB Live Tune/Form1.cs
@@ -176,7 +176,7 @@ namespace QO_100_WB_Live_Tune
         private void button1_Click(object sender, EventArgs e)
         {
             if (!connected) {
-                ws = new WebSocket("wss://eshail.batc.org.uk/wb/fft_m0dtslivetune");
+                ws = new WebSocket("wss://eshail.batc.org.uk/wb/fft", "fft_m0dtslivetune");
                 ws.OnMessage += (ss, ee) => NewData(sender, ee.RawData);
                 ws.OnOpen += (ss, ee) => { connected = true; button1.Text = "Disconnect"; };
                 ws.OnClose += (ss, ee) => { connected = false; button1.Text = "Connect"; };


### PR DESCRIPTION
It turns out that it's an nginx config regex bug in my end that's allowing the current URL here to work.

This changes it to use the true URL, and then select your sub-protocol (which is also how I switch between slow/fast).

Note that I've not been able to test this, but according to the websocket-sharp documentation this is the way to do it.